### PR TITLE
Fix updateWeightsGradually divide-by-two bug for Gnosis Safe

### DIFF
--- a/src/store/modules/broadcast.ts
+++ b/src/store/modules/broadcast.ts
@@ -565,9 +565,7 @@ const actions = {
   ) => {
     commit('INCREASE_WEIGHT_REQUEST');
     try {
-      newWeight = toWei(newWeight)
-        .div(2)
-        .toString();
+      newWeight = toWei(newWeight).toString();
       const tokenMetadata = rootState.web3.tokenMetadata[token];
       const decimals = tokenMetadata ? tokenMetadata.decimals : null;
       tokenAmountIn = denormalizeBalance(tokenAmountIn, decimals)
@@ -601,9 +599,7 @@ const actions = {
   ) => {
     commit('DECREASE_WEIGHT_REQUEST');
     try {
-      newWeight = toWei(newWeight)
-        .div(2)
-        .toString();
+      newWeight = toWei(newWeight).toString();
       // Pool can always take pool tokens from Safe so no approval needed
       const decreaseWeightTransaction = makeGnosisTransaction(
         'ConfigurableRightsPool',
@@ -628,9 +624,7 @@ const actions = {
     commit('UPDATE_WEIGHTS_GRADUALLY_REQUEST');
     try {
       newWeights = tokens.map(token => {
-        return toWei(newWeights[token])
-          .div(2)
-          .toString();
+        return toWei(newWeights[token]).toString();
       });
       const transaction = makeGnosisTransaction(
         'ConfigurableRightsPool',
@@ -679,9 +673,7 @@ const actions = {
       balance = denormalizeBalance(balance, decimals)
         .integerValue(BigNumber.ROUND_DOWN)
         .toString();
-      denormalizedWeight = toWei(denormalizedWeight)
-        .div(2)
-        .toString();
+      denormalizedWeight = toWei(denormalizedWeight).toString();
       const transaction = makeGnosisTransaction(
         'ConfigurableRightsPool',
         poolAddress,


### PR DESCRIPTION
This is a hot-fix for the denormalized weights in an LBP (or any CRP) to enable linear weight changes. Prior to this fix, pools are created with total denorm weight of 25, but updates are issued with total denorm of 12.5. This breaks linearity for Gnosis Safes, whereas the main Balancer UI enforces linearity.